### PR TITLE
test: fix typo in test assertion error message

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -23,12 +23,13 @@ class UnitTests(unittest.TestCase):
         probability = prob_calculator.experiment(hat=hat, expected_balls={"blue":2,"green":1}, num_balls_drawn=4, num_experiments=1000)
         actual = probability
         expected = 0.272
-        self.assertAlmostEqual(actual, expected, delta = 0.01, msg = 'Expected experiemnt method to return a different probability.')
+        self.assertAlmostEqual(actual, expected, delta = 0.01, msg = 'Expected experiment method to return a different probability.')
         hat = prob_calculator.Hat(yellow=5,red=1,green=3,blue=9,test=1)
         probability = prob_calculator.experiment(hat=hat, expected_balls={"yellow":2,"blue":3,"test":1}, num_balls_drawn=20, num_experiments=100)
         actual = probability
         expected = 1.0
         self.assertAlmostEqual(actual, expected, delta = 0.01, msg = 'Expected experiment method to return a different probability.')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes typo in test assertion error message.
```diff
- ...experiemnt...
+ ...experiment...
```